### PR TITLE
Add TypeScript definitions for SunCalc

### DIFF
--- a/src/suncalc.d.ts
+++ b/src/suncalc.d.ts
@@ -1,0 +1,50 @@
+declare module "suncalc" {
+export interface GetTimesResult {
+    dawn: Date;
+    dusk: Date;
+    goldenHour: Date;
+    goldenHourEnd: Date;
+    nadir: Date;
+    nauticalDawn: Date;
+    nauticalDusk: Date;
+    night: Date;
+    nightEnd: Date;
+    solarNoon: Date;
+    sunrise: Date;
+    sunriseEnd: Date;
+    sunset: Date;
+    sunsetStart: Date;
+}
+
+export interface GetSunPositionResult {
+    altitude: number;
+    azimuth: number;
+}
+
+export interface GetMoonPositionResult {
+    altitude: number;
+    azimuth: number;
+    distance: number;
+    parallacticAngle: number;
+}
+
+export interface GetMoonIlluminationResult {
+    fraction: number;
+    phase: number;
+    angle: number;
+}
+
+export interface GetMoonTimes {
+    rise: Date;
+    set: Date;
+    alwaysUp?: true;
+    alwaysDown?: true;
+}
+
+export function getTimes(date: Date, latitude: number, longitude: number, height?: number): GetTimesResult;
+export function addTime(angleInDegrees: number, morningName: string, eveningName: string): void;
+export function getPosition(timeAndDate: Date, latitude: number, longitude: number): GetSunPositionResult;
+export function getMoonPosition(timeAndDate: Date, latitude: number, longitude: number): GetMoonPositionResult;
+export function getMoonIllumination(timeAndDate: Date): GetMoonIlluminationResult;
+export function getMoonTimes(date: Date, latitude: number, longitude: number, inUTC?: boolean): GetMoonTimes;
+}


### PR DESCRIPTION
## Summary
- create `src/suncalc.d.ts` so SunCalc can be used in TypeScript projects

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68403ecbc79c832b860f094583aa7e25