### PR TITLE
Add solar watch display

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import './App.css';
 import { useEffect, useState } from 'react';
 import SunCalc from 'suncalc';
+import SolarWatch from './SolarWatch';
 
 interface SunTimes {
   dawn: Date;
@@ -45,13 +46,15 @@ function App() {
       {error && <p>{error}</p>}
       {!error && !sunTimes && <p>Obtaining location&hellip;</p>}
       {sunTimes && (
-        <table className="sun-table" style={{ margin: '0 auto' }}>
-          <thead>
-            <tr>
-              <th>Event</th>
-              <th>Time</th>
-            </tr>
-          </thead>
+        <>
+          <SolarWatch solarNoon={sunTimes.solarNoon} />
+          <table className="sun-table" style={{ margin: '0 auto' }}>
+            <thead>
+              <tr>
+                <th>Event</th>
+                <th>Time</th>
+              </tr>
+            </thead>
           <tbody>
             <tr>
               <td>Dawn</td>
@@ -75,6 +78,7 @@ function App() {
             </tr>
           </tbody>
         </table>
+        </>
       )}
     </div>
   );

--- a/src/SolarWatch.tsx
+++ b/src/SolarWatch.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+
+interface Props {
+  solarNoon: Date;
+}
+
+const RADIUS = 80;
+const STROKE = 10;
+const CIRC = 2 * Math.PI * RADIUS;
+
+function SolarWatch({ solarNoon }: Props) {
+  const [now, setNow] = useState(new Date());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const noonMinutes =
+    solarNoon.getHours() * 60 +
+    solarNoon.getMinutes() +
+    solarNoon.getSeconds() / 60;
+  const nowMinutes = now.getHours() * 60 + now.getMinutes() + now.getSeconds() / 60;
+
+  // 12:00 should match solar noon
+  const offset = 720 - noonMinutes; // minutes to add to local time
+  const solarMinutes = (nowMinutes + offset + 1440) % 1440; // wrap around 24h
+
+  const ratio = solarMinutes / 720; // position on 12-hour dial
+  const angle = ratio * 360;
+  const dashOffset = CIRC * (1 - ratio);
+
+  return (
+    <svg width={(RADIUS + STROKE) * 2} height={(RADIUS + STROKE) * 2}>
+      <g transform={`translate(${RADIUS + STROKE}, ${RADIUS + STROKE})`}>
+        <circle
+          r={RADIUS}
+          fill="none"
+          stroke="#eee"
+          strokeWidth={STROKE}
+        />
+        <circle
+          r={RADIUS}
+          fill="none"
+          stroke="#00f"
+          strokeWidth={STROKE}
+          strokeDasharray={CIRC}
+          strokeDashoffset={dashOffset}
+          transform="rotate(-90)"
+        />
+        <line
+          x1="0"
+          y1="0"
+          x2="0"
+          y2={-RADIUS + STROKE}
+          stroke="#f00"
+          strokeWidth="2"
+          transform={`rotate(${angle})`}
+        />
+      </g>
+    </svg>
+  );
+}
+
+export default SolarWatch;


### PR DESCRIPTION
## Summary
- show an animated sun-time watch derived from Solar Noon
- compute solar-time offset from the SunCalc library

## Testing
- `npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_68404a6d5c14832b9667081cc75cb6ae