### PR TITLE
Rotate and reposition times table

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,29 @@ function App() {
       {!error && !sunTimes && <p>Obtaining location&hellip;</p>}
       {sunTimes && (
         <>
+          <table
+            className="sun-table"
+            style={{ margin: '0 auto', marginBottom: '20px' }}
+          >
+            <thead>
+              <tr>
+                <th>Dawn</th>
+                <th>Sunrise</th>
+                <th>Solar Noon</th>
+                <th>Sunset</th>
+                <th>Dusk</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>{formatTime(sunTimes.dawn)}</td>
+                <td>{formatTime(sunTimes.sunrise)}</td>
+                <td>{formatTime(sunTimes.solarNoon)}</td>
+                <td>{formatTime(sunTimes.sunset)}</td>
+                <td>{formatTime(sunTimes.dusk)}</td>
+              </tr>
+            </tbody>
+          </table>
           <SolarWatch
             dawn={sunTimes.dawn}
             sunrise={sunTimes.sunrise}
@@ -54,36 +77,6 @@ function App() {
             sunset={sunTimes.sunset}
             dusk={sunTimes.dusk}
           />
-          <table className="sun-table" style={{ margin: '0 auto' }}>
-            <thead>
-              <tr>
-                <th>Event</th>
-                <th>Time</th>
-              </tr>
-            </thead>
-          <tbody>
-            <tr>
-              <td>Dawn</td>
-              <td>{formatTime(sunTimes.dawn)}</td>
-            </tr>
-            <tr>
-              <td>Sunrise</td>
-              <td>{formatTime(sunTimes.sunrise)}</td>
-            </tr>
-            <tr>
-              <td>Solar Noon</td>
-              <td>{formatTime(sunTimes.solarNoon)}</td>
-            </tr>
-            <tr>
-              <td>Sunset</td>
-              <td>{formatTime(sunTimes.sunset)}</td>
-            </tr>
-            <tr>
-              <td>Dusk</td>
-              <td>{formatTime(sunTimes.dusk)}</td>
-            </tr>
-          </tbody>
-        </table>
         </>
       )}
     </div>


### PR DESCRIPTION
## Summary
- rotate the solar times table to use event names as column headers
- display the table before the SolarWatch SVG
- add spacing between the table and SVG

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6840513ee1ec832bbaf191b191ca893b